### PR TITLE
Use the source table exclusively to define schema of target table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .DS_Store
+scratch*
+src/function.zip
+.venv/

--- a/README.md
+++ b/README.md
@@ -12,16 +12,13 @@ This project aims to facilitate zero-downtime cross-account migration of Amazon 
 - AWS CLI (Command Line Interface) configured with appropriate credentials.
 - Enable Point-in-Time Recovery (PITR) on the source Amazon DynamoDB table.
 
-## Limitations
-- Global Secondary Index (GSI) Creation: This version of the code does not currently support the creation of Global Secondary Indexes (GSIs) during the import process. If the source table contains GSIs, they must be created explicitly after the import is completed. GSI support will be implemented in future updates.
-- Time to Live (TTL) Enablement: Please note that Time to Live (TTL) must be explicitly enabled on the target table if the source table had TTL configured.
 
 ## Getting Started
 1. Clone the git repository.
 2. Create a zip file for AWS Lambda function:
 ```bash
-cd src         
-pip install -r requirements.txt --target ./lambda-code      
+cd src
+pip install -r requirements.txt --target ./lambda-code
 cp dynamodb-cross-account-cdc-lambda-function.py lambda-code
 cd lambda-code
 zip -r function.zip .
@@ -38,7 +35,7 @@ rm -r lambda-code
 
 
 ## Usage
-To initiate the migration, execute the src/dynamodb-initial-load-and-cdc-setup.py script in your terminal with the user or role you specified in the CloudFormation template. 
+To initiate the migration, execute the src/dynamodb-initial-load-and-cdc-setup.py script in your terminal with the user or role you specified in the CloudFormation template.
 ```bash
 python dynamodb-initial-load-and-cdc-setup.py \
 --source-region <source-region> \
@@ -49,10 +46,6 @@ python dynamodb-initial-load-and-cdc-setup.py \
 --target-account-id <target-account-id> \
 --target-s3-bucket-name <target-s3-bucket-name> \
 --target-role-name <target-role-name> \
---target-table-pk-name <target-table-pk-name> \
---target-table-sk-name <target-table-sk-name> \
---target-table-pk-type <target-table-pk-type> \
---target-table-sk-type <target-table-sk-type> \
 --target-table-read-capacity <target-table-read-capacity> \
 --target-table-write-capacity <target-table-write-capacity> \
 --cdc-lambda-function-name <cdc-lambda-function-name> \
@@ -71,10 +64,6 @@ python dynamodb-initial-load-and-cdc-setup.py \
 * `--target-account-id` (required): Target AWS account ID
 * `--target-s3-bucket-name`: Target S3 bucket name (default: dynamodb-export-to-s3-target-region-target-account-id)
 * `--target-role-name` (default: "cross_account_assume_role"): Target role name
-* `--target-table-pk-name`: Primary key name of the target DynamoDB table (default: Primary key name of the source table)
-* `--target-table-sk-name`: Sort key name of the target DynamoDB table (default: Sort key name of the source table)
-* `--target-table-pk-type`: Primary key type of the target DynamoDB table (default: Primary key type of the source table)
-* `--target-table-sk-type`: Sort key type of the target DynamoDB table (default: Sort key type of the source table)
 * `--target-table-read-capacity` (required): Read capacity of the target DynamoDB table
 * `--target-table-write-capacity` (required): Write capacity of the target DynamoDB table
 * `--cdc-lambda-function-name` (default: "dynamodb-cross-account-cdc-lambda-function"): Name of the CDC Lambda function

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ This project aims to facilitate zero-downtime cross-account migration of Amazon 
 - AWS CLI (Command Line Interface) configured with appropriate credentials.
 - Enable Point-in-Time Recovery (PITR) on the source Amazon DynamoDB table.
 
+## Limitations
+- Global Secondary Index (GSI) read capacity: A GSI read capacity argument is required if the source table has GSI and the source table is using on demand capacity.
+- Read capacity for multiple GSIs:  Only one GSI read capacity can be provided.  Use the maximum of all GSI read capacities.
+- Write capacity for multiple GSIs:  Only one GSI write capacity can be provided.  Use the maximum of all GSI write capacities.
 
 ## Getting Started
 1. Clone the git repository.
@@ -66,6 +70,8 @@ python dynamodb-initial-load-and-cdc-setup.py \
 * `--target-role-name` (default: "cross_account_assume_role"): Target role name
 * `--target-table-read-capacity` (required): Read capacity of the target DynamoDB table
 * `--target-table-write-capacity` (required): Write capacity of the target DynamoDB table
+* `--target-gsi-read-capacity`: Read capacity of the target DynamoDB GSI (applies to all GSIs).
+* `--target-gsi-write-capacity`: Write capacity of the target DynamoDB GSI (applies to all GSIs).  GSI write capacity will default to table write capacity if not specified
 * `--cdc-lambda-function-name` (default: "dynamodb-cross-account-cdc-lambda-function"): Name of the CDC Lambda function
 * `--lambda-event-source-batch-size` (default: 100): The maximum number of records in each batch that Lambda pulls from DynamoDB stream
 

--- a/src/dynamodb-initial-load-and-cdc-setup.py
+++ b/src/dynamodb-initial-load-and-cdc-setup.py
@@ -425,7 +425,7 @@ class DynamoDBInitialLoadAndCDC:
         }
 
         local_secondary_indexes = []
-        for index in describe_table_response['Table'].get(LSI, [{}]):
+        for index in describe_table_response['Table'].get(LSI, []):
             # Append filtered index attributes to LSI property
             local_secondary_indexes.append({x: index[x] for x in SI_ATTRIBUTES})
 
@@ -433,7 +433,7 @@ class DynamoDBInitialLoadAndCDC:
             result[SCHEMA_SPEC_KEY][LSI] = local_secondary_indexes
 
         global_secondary_indexes = []
-        for index in describe_table_response['Table'].get(GSI, [{}]):
+        for index in describe_table_response['Table'].get(GSI, []):
             gsi = {x: index[x] for x in SI_ATTRIBUTES}
             # GSI has optional RCU/WCU
             if index.get("ProvisionedThroughput", {}).get(RCU, None):

--- a/src/dynamodb-initial-load-and-cdc-setup.py
+++ b/src/dynamodb-initial-load-and-cdc-setup.py
@@ -4,8 +4,20 @@ import logging
 import argparse
 import time
 from datetime import datetime,timedelta
+from typing import Any, Dict
 import pytz
 from botocore.exceptions import ClientError
+
+# Constants used as key names
+SCHEMA_SPEC_KEY = "schema"
+TTL_SPEC_KEY = "ttl"
+# Constants present in table definition
+RCU = "ReadCapacityUnits"
+WCU = "WriteCapacityUnits"
+GSI = "GlobalSecondaryIndexes"
+LSI = "LocalSecondaryIndexes"
+# Common attributes for LSI and GSI
+SI_ATTRIBUTES = set(["IndexName", "KeySchema", "Projection"])
 
 # Initialize Logger
 logger = logging.getLogger()
@@ -36,10 +48,6 @@ class DynamoDBInitialLoadAndCDC:
         parser.add_argument("--target-account-id", required=True, help="Target AWS account ID")
         parser.add_argument("--target-s3-bucket-name", required=False, help="Target S3 bucket name")
         parser.add_argument("--target-role-name", required=False, default="cross_account_assume_role", help="Target role name")
-        parser.add_argument("--target-table-pk-name", required=False, help="Primary key name of the target DynamoDB table")
-        parser.add_argument("--target-table-sk-name", required=False, help="Sort key name of the target DynamoDB table")
-        parser.add_argument("--target-table-pk-type", required=False, help="Primary key type of the target DynamoDB table")
-        parser.add_argument("--target-table-sk-type", required=False, help="Sort key type of the target DynamoDB table")
         parser.add_argument("--target-table-read-capacity", required=True, help="Read capacity of the target DynamoDB table")
         parser.add_argument("--target-table-write-capacity", required=True, help="Write capacity of the target DynamoDB table")
         parser.add_argument("--cdc-lambda-function-name", required=False, default="dynamodb-cross-account-cdc-lambda-function", help="Name of the CDC Lambda function")
@@ -53,7 +61,7 @@ class DynamoDBInitialLoadAndCDC:
             session = boto3.session.Session()
             self.source_region = session.region_name
         else:
-            self.source_region = args.source_region 
+            self.source_region = args.source_region
 
         # create a DynamoDB client object for the source region
         self.dynamodb = boto3.client('dynamodb', region_name=self.source_region)
@@ -88,12 +96,6 @@ class DynamoDBInitialLoadAndCDC:
         target_role_name = args.target_role_name
         self.target_role_arn = f"arn:aws:iam::{self.target_account_id}:role/{target_role_name}"
 
-        # if any of target table attribute is not provided, use the source table for the missing attributes
-        self.target_table_pk_name = args.target_table_pk_name if args.target_table_pk_name is not None else self.desc_src_tab_response['Table']['KeySchema'][0]['AttributeName']
-        self.target_table_sk_name = args.target_table_sk_name if args.target_table_sk_name is not None else self.desc_src_tab_response['Table']['KeySchema'][1]['AttributeName']
-        self.target_table_pk_type = args.target_table_pk_type if args.target_table_pk_type is not None else self.desc_src_tab_response['Table']['AttributeDefinitions'][0]['AttributeType']
-        self.target_table_sk_type = args.target_table_sk_type if args.target_table_sk_type is not None else self.desc_src_tab_response['Table']['AttributeDefinitions'][1]['AttributeType']
-        
         self.target_table_read_capacity = int(args.target_table_read_capacity)
         self.target_table_write_capacity = int(args.target_table_write_capacity)
         self.cdc_lambda_function_name = args.cdc_lambda_function_name
@@ -128,7 +130,7 @@ class DynamoDBInitialLoadAndCDC:
         Returns:
             None
         '''
-        # check if DynamoDB streams is already enabled on the source table, if not then enable it  
+        # check if DynamoDB streams is already enabled on the source table, if not then enable it
         if ('StreamSpecification' not in self.desc_src_tab_response.get('Table')) or ( not self.desc_src_tab_response.get('Table').get('StreamSpecification','').get('StreamEnabled')):
             # enable DynamoDB stream on the source table
             response = self.dynamodb.update_table(
@@ -162,7 +164,7 @@ class DynamoDBInitialLoadAndCDC:
             logger.info("DynamoDB stream is already enabled on the source table")
             self.is_dynamodb_stream_enabled = True
             self.source_table_stream_arn = self.desc_src_tab_response['Table']['LatestStreamArn']
-    
+
     def export_dynamodb_table_to_s3(self):
         '''
         Export the source DynamoDB table to S3 bucket in the target account.
@@ -176,9 +178,9 @@ class DynamoDBInitialLoadAndCDC:
         self.s3_prefix = f"{current_time}-{self.source_table_name}-export"
 
         # create an export task to export the source DynamoDB table data to S3 bucket in target account
-        logger.info(f"Exporting DynamoDB {self.source_table_name} table to S3 location s3://{self.target_s3_bucket_name}/{self.s3_prefix} " 
+        logger.info(f"Exporting DynamoDB {self.source_table_name} table to S3 location s3://{self.target_s3_bucket_name}/{self.s3_prefix} "
                     f"in the target account")
-       
+
         # If the source table already has a DynamoDB stream enabled, export the table with the latest timestamp
         if self.is_dynamodb_stream_enabled:
             response = self.dynamodb.export_table_to_point_in_time(
@@ -216,7 +218,7 @@ class DynamoDBInitialLoadAndCDC:
             else:
                 logger.info(f"Export task status is {response['ExportDescription']['ExportStatus']} , waiting for 30 seconds to complete")
                 time.sleep(30)
-            
+
         if response['ExportDescription']['ExportStatus'] == 'COMPLETED':
             logger.info(f"DynamoDB {self.source_table_name} table is exported to S3")
         else:
@@ -262,15 +264,19 @@ class DynamoDBInitialLoadAndCDC:
 
     def import_data_from_s3_to_dynamodb(self):
         '''
-        Import data from S3 to the target DynamoDB table in the target account. After the import completes, 
+        Import data from S3 to the target DynamoDB table in the target account. After the import completes,
         establish a resource-based policy on the target table to grant write access to the CDC AWS Lambda function.
-        
+
         Parameters:
             None
         Returns:
             None
         '''
-       # assume target role
+        source_table_specs = self.describe_source_table()
+        if self.target_table_name:
+            source_table_specs[SCHEMA_SPEC_KEY]["TableName"] = self.target_table_name
+
+        # assume target role
         target_role_credentials = self.assume_target_role()
 
         # get the latest S3 key prefix
@@ -281,7 +287,7 @@ class DynamoDBInitialLoadAndCDC:
                                 aws_access_key_id=target_role_credentials['AccessKeyId'],
                                 aws_secret_access_key=target_role_credentials['SecretAccessKey'],
                                 aws_session_token=target_role_credentials['SessionToken'])
-        
+
         # import data from S3 to DynamoDB table in target account
         logger.info(f"Importing DynamoDB table {self.source_table_name} in target account from S3 location s3://{self.target_s3_bucket_name}/{S3KeyPrefix}")
         response = dynamodb.import_table(
@@ -291,37 +297,10 @@ class DynamoDBInitialLoadAndCDC:
             },
             InputFormat = 'DYNAMODB_JSON',
             InputCompressionType = 'GZIP',
-            TableCreationParameters = {
-                'TableName': self.target_table_name,
-                'KeySchema': [
-                    {
-                        'AttributeName': self.target_table_pk_name,
-                        'KeyType': 'HASH'
-                    },
-                    {
-                        'AttributeName': self.target_table_sk_name,
-                        'KeyType': 'RANGE'
-                    }
-                ],
-                'AttributeDefinitions': [
-                    {
-                        'AttributeName': self.target_table_pk_name,
-                        'AttributeType': self.target_table_pk_type
-                    },
-                    {
-                        'AttributeName': self.target_table_sk_name,
-                        'AttributeType': self.target_table_sk_type
-                    }
-                ],
-                'ProvisionedThroughput': {
-                    'ReadCapacityUnits': self.target_table_read_capacity,
-                    'WriteCapacityUnits': self.target_table_write_capacity
-                }
-            },
-
+            TableCreationParameters = source_table_specs[SCHEMA_SPEC_KEY],
         )
 
-        # wait for the import task to complete by checking the status 
+        # wait for the import task to complete by checking the status
         while True:
             try:
                 response = dynamodb.describe_import(
@@ -350,7 +329,14 @@ class DynamoDBInitialLoadAndCDC:
             logger.info("Import is completed")
         else:
             logger.error(f"Import task failed with status {response['ImportTableDescription']['ImportStatus']}")
-            raise Exception(f"Import task failed with status {response['ImportTableDescription']['ImportStatus']}")     
+            raise Exception(f"Import task failed with status {response['ImportTableDescription']['ImportStatus']}")
+
+        # Key is only present if source table has a TTL
+        if TTL_SPEC_KEY in source_table_specs:
+            dynamodb.update_time_to_live(
+                TableName=self.target_table_name,
+                TimeToLiveSpecification=source_table_specs[TTL_SPEC_KEY],
+            )
 
         # Create a resource-based policy on the target DynamoDB table for the CDC AWS Lambda function.
         self.cdc_lambda_config = self.lambda_client.get_function_configuration(FunctionName=self.cdc_lambda_function_name)
@@ -375,8 +361,8 @@ class DynamoDBInitialLoadAndCDC:
         dynamodb.put_resource_policy(
                     ResourceArn=response['ImportTableDescription']['TableArn'],
                     Policy= policy_document_str
-                )             
-              
+                )
+
     def create_ddb_stream_lambda_trigger(self):
         '''
         Enables the DynamoDB trigger to the AWS Lambda function for CDC
@@ -415,6 +401,63 @@ class DynamoDBInitialLoadAndCDC:
         )
         logger.info(f"Created a Lambda function trigger on the DynamoDB stream of {self.source_table_name}")
 
+    def describe_source_table(self) -> Dict[str, Any]:
+        '''
+        Gets the table creation and TTL details via an inspection of the source table
+        Parameters:
+            None
+        Returns:
+            dict: The table creation and TTL details
+        '''
+        result: Dict[str, Any]= {}
+        describe_table_response = self.dynamodb.describe_table(
+            TableName=self.source_table_name
+        )
+        # Set required attributes
+        result[SCHEMA_SPEC_KEY] = {
+            x: describe_table_response['Table'][x] for x in ["TableName", "KeySchema", "AttributeDefinitions"]
+        }
+        # Hard-code to provisioned mode.  A future enhancement would be to multiply current RCU/WCU by 2 for prewarming
+        result[SCHEMA_SPEC_KEY]["BillingMode"] = "PROVISIONED"
+        result[SCHEMA_SPEC_KEY]["ProvisionedThroughput"] = {
+            "ReadCapacityUnits": self.target_table_read_capacity,
+            "WriteCapacityUnits": self.target_table_write_capacity,
+        }
+
+        local_secondary_indexes = []
+        for index in describe_table_response['Table'].get(LSI, [{}]):
+            # Append filtered index attributes to LSI property
+            local_secondary_indexes.append({x: index[x] for x in SI_ATTRIBUTES})
+
+        if local_secondary_indexes:
+            result[SCHEMA_SPEC_KEY][LSI] = local_secondary_indexes
+
+        global_secondary_indexes = []
+        for index in describe_table_response['Table'].get(GSI, [{}]):
+            gsi = {x: index[x] for x in SI_ATTRIBUTES}
+            # GSI has optional RCU/WCU
+            if index.get("ProvisionedThroughput", {}).get(RCU, None):
+                gsi["ProvisionedThroughput"][RCU] = index["ProvisionedThroughput"][RCU]
+            if index.get("ProvisionedThroughput", {}).get(WCU, None):
+                gsi["ProvisionedThroughput"][WCU] = index["ProvisionedThroughput"][WCU]
+
+            global_secondary_indexes.append(gsi)
+
+        if global_secondary_indexes:
+            result[SCHEMA_SPEC_KEY][GSI] = global_secondary_indexes
+
+        # Get TTL details (if any)
+        ttl_response = self.dynamodb.describe_time_to_live(
+            TableName=self.source_table_name
+        )
+        status = ttl_response.get("TimeToLiveDescription", {}).get("TimeToLiveStatus", None)
+        enabled = status and status.startswith("ENABL")
+        if enabled:
+            result[TTL_SPEC_KEY]["Enabled"] = enabled
+            result[TTL_SPEC_KEY]["AttributeName"] = ttl_response["TimeToLiveDescription"]["AttributeName"]
+
+        return result
+
 
 if __name__ == "__main__":
     # create DynamoDBInitialLoadAndCDC object
@@ -424,7 +467,7 @@ if __name__ == "__main__":
     # check if PITR is enabled
     if not ddb_initial_load_and_cdc.check_if_PITR_enabled():
         raise ValueError("PITR is disabled on the source table. Enable PITR before starting the migration")
-    
+
     # enable DynamoDB stream on the source table
     ddb_initial_load_and_cdc.enable_dynamodb_stream_on_source_table()
 

--- a/src/dynamodb-initial-load-and-cdc-setup.py
+++ b/src/dynamodb-initial-load-and-cdc-setup.py
@@ -436,12 +436,6 @@ class DynamoDBInitialLoadAndCDC:
         if local_secondary_indexes:
             result[SCHEMA_SPEC_KEY][LSI] = local_secondary_indexes
 
-        # TODO:
-        # If the GSI has provisioned capacity, use those values
-        # Add optional arguments for GSI RCU and WCU
-        # If we find a GSI, that will make the GSI RCU value required (i.e. fail here if missing)
-        # If no GSI WCU is present, use the base table WCU
-        # Update documentation for all of the above
         global_secondary_indexes = []
         for index in describe_table_response['Table'].get(GSI, []):
             gsi = {x: index[x] for x in SI_ATTRIBUTES}

--- a/src/dynamodb-initial-load-and-cdc-setup.py
+++ b/src/dynamodb-initial-load-and-cdc-setup.py
@@ -436,6 +436,8 @@ class DynamoDBInitialLoadAndCDC:
         for index in describe_table_response['Table'].get(GSI, []):
             gsi = {x: index[x] for x in SI_ATTRIBUTES}
             # GSI has optional RCU/WCU
+            if "ProvisionedThroughput" in index:
+                gsi["ProvisionedThroughput"] = {}
             if index.get("ProvisionedThroughput", {}).get(RCU, None):
                 gsi["ProvisionedThroughput"][RCU] = index["ProvisionedThroughput"][RCU]
             if index.get("ProvisionedThroughput", {}).get(WCU, None):
@@ -453,6 +455,7 @@ class DynamoDBInitialLoadAndCDC:
         status = ttl_response.get("TimeToLiveDescription", {}).get("TimeToLiveStatus", None)
         enabled = status and status.startswith("ENABL")
         if enabled:
+            result[TTL_SPEC_KEY] = {}
             result[TTL_SPEC_KEY]["Enabled"] = enabled
             result[TTL_SPEC_KEY]["AttributeName"] = ttl_response["TimeToLiveDescription"]["AttributeName"]
 

--- a/target_cfn_template.yaml
+++ b/target_cfn_template.yaml
@@ -19,7 +19,7 @@ Parameters:
   SourceUserOrRoleName:
     Type: String
     Description: 'The name of the principal user or role in the source account'
-  
+
 
 Conditions:
   IsUser:
@@ -85,14 +85,14 @@ Resources:
             Effect: Allow
             Principal:
               Service: logging.s3.amazonaws.com
-            Resource: !Join 
+            Resource: !Join
               - ''
               - - 'arn:aws:s3:::'
                 - !Ref LoggingBucket
                 - /*
             Condition:
               ArnLike:
-                'aws:SourceArn': !GetAtt 
+                'aws:SourceArn': !GetAtt
                   - S3Bucket
                   - Arn
               StringEquals:
@@ -106,7 +106,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: 
+              AWS:
                 - !If [IsUser, !Sub 'arn:aws:iam::${SourceAWSAccountNumber}:user/${SourceUserOrRoleName}', !Sub 'arn:aws:iam::${SourceAWSAccountNumber}:role/${SourceUserOrRoleName}']
             Action:
               - 'sts:AssumeRole'
@@ -122,7 +122,8 @@ Resources:
                   - 'dynamodb:DescribeTable'
                   - 'dynamodb:DescribeImport'
                   - 'dynamodb:PutResourcePolicy'
-                Resource: 
+                  - 'dynamodb:UpdateTimeToLive'
+                Resource:
                   - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${TargetDynamoDBTableName}'
                   - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${TargetDynamoDBTableName}/import/*'
         - PolicyName: 'cloudwatch-access-policy'
@@ -137,7 +138,7 @@ Resources:
                   - 'logs:DescribeLogStreams'
                   - 'logs:PutLogEvents'
                   - 'logs:PutRetentionPolicy'
-                Resource: 
+                Resource:
                   - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*'
         - PolicyName: 'S3-access-policy'
           PolicyDocument:
@@ -147,6 +148,6 @@ Resources:
                 Action:
                   - 's3:GetObject'
                   - 's3:ListBucket'
-                Resource: 
+                Resource:
                   - !Sub 'arn:aws:s3:::dynamodb-export-to-s3-${AWS::Region}-${AWS::AccountId}/*'
                   - !Sub 'arn:aws:s3:::dynamodb-export-to-s3-${AWS::Region}-${AWS::AccountId}'


### PR DESCRIPTION
*Issue #, if available:* 1

*Description of changes:* Exclusively use the source table to define the schema for the target table.  The one exception is table name, which can be overridden with the commandline parameter.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
