### PR TITLE
Ddbstreams fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ rm -r lambda-code
 
 
 ## Usage
-To initiate the migration, execute the src/dynamodb-initial-load-and-cdc-setup.py script in your terminal with the user or role you specified in the CloudFormation template.
+To initiate the migration, execute the src/dynamodb-initial-load-and-cdc-setup.py script in your terminal with the user or role you specified in the CloudFormation template. Ensure this script is run from the source account.
+
 ```bash
 python dynamodb-initial-load-and-cdc-setup.py \
 --source-region <source-region> \
@@ -56,9 +57,6 @@ python dynamodb-initial-load-and-cdc-setup.py \
 --lambda-event-source-batch-size <lambda-event-source-batch-size>
 ```
 
-![demo-usage](images/demo-usage.gif)
-
-
 ### Argument Details
 * `--source-region` (required): Region of the source DynamoDB table
 * `--source-table-name` (required): Source DynamoDB table name
@@ -74,6 +72,10 @@ python dynamodb-initial-load-and-cdc-setup.py \
 * `--target-gsi-write-capacity`: Write capacity of the target DynamoDB GSI (applies to all GSIs).  GSI write capacity will default to table write capacity if not specified
 * `--cdc-lambda-function-name` (default: "dynamodb-cross-account-cdc-lambda-function"): Name of the CDC Lambda function
 * `--lambda-event-source-batch-size` (default: 100): The maximum number of records in each batch that Lambda pulls from DynamoDB stream
+
+
+![demo-usage](images/demo-usage.gif)
+
 
 Above script will perform the initial load and then set up the CDC for the ongoing replication.
 

--- a/source_cfn_template.yaml
+++ b/source_cfn_template.yaml
@@ -240,7 +240,7 @@ Resources:
   
 
 Outputs:
-  DynamoDBCDCFunctionArn:
-    Description: 'ARN of the DynamoDB CDC Lambda function'
-    Value: !GetAtt DynamodbCrossAccountCdcLambdaFunction.Arn
+  DynamoDBCDCFunction:
+    Description: 'DynamoDB CDC Lambda function name'
+    Value: !Ref DynamodbCrossAccountCdcLambdaFunction
   

--- a/src/dynamodb-initial-load-and-cdc-setup.py
+++ b/src/dynamodb-initial-load-and-cdc-setup.py
@@ -95,7 +95,7 @@ class DynamoDBInitialLoadAndCDC:
         self.target_table_name = args.target_table_name if args.target_table_name is not None else self.source_table_name
 
         self.target_account_id = args.target_account_id
-        self.target_s3_bucket_name = args.target_s3_bucket_name if args.target_table_name is not None else f"dynamodb-export-to-s3-{self.target_region}-{self.target_account_id}"
+        self.target_s3_bucket_name = args.target_s3_bucket_name if args.target_s3_bucket_name is not None else f"dynamodb-export-to-s3-{self.target_region}-{self.target_account_id}"
 
         # get the target role ARN
         target_role_name = args.target_role_name

--- a/src/dynamodb-initial-load-and-cdc-setup.py
+++ b/src/dynamodb-initial-load-and-cdc-setup.py
@@ -70,6 +70,9 @@ class DynamoDBInitialLoadAndCDC:
         # create lambda client
         self.lambda_client = boto3.client('lambda', region_name=self.source_region)
 
+        # create a DynamoDBStreams client object for the source region
+        self.dynamodbstreams = boto3.client('dynamodbstreams', region_name=self.source_region)
+        
         # check if source table exists
         self.source_table_name = args.source_table_name
         try:
@@ -137,7 +140,7 @@ class DynamoDBInitialLoadAndCDC:
         # check if DynamoDB streams is already enabled on the source table, if not then enable it
         if ('StreamSpecification' not in self.desc_src_tab_response.get('Table')) or ( not self.desc_src_tab_response.get('Table').get('StreamSpecification','').get('StreamEnabled')):
             # enable DynamoDB stream on the source table
-            response = self.dynamodb.update_table(
+            upd_table_response = self.dynamodb.update_table(
             TableName=self.source_table_name,
             StreamSpecification={
                 'StreamEnabled': True,
@@ -145,21 +148,18 @@ class DynamoDBInitialLoadAndCDC:
             }
             )
 
+            # wait for DynamoDB streams to be enabled
+            while True:
+                ddb_streams_response = self.dynamodbstreams.describe_stream(
+                    StreamArn=upd_table_response['TableDescription']['LatestStreamArn']
+                )
+                if ddb_streams_response['StreamDescription']['StreamStatus'] == 'ENABLED':
+                    # get the stream enabled timestamp in epoch time
+                    self.dynamodb_stream_enabled_ts = int(time.time()) 
+                    break
+    
             # get the stream ARN
-            self.source_table_stream_arn = response['TableDescription']['LatestStreamArn']
-
-            timestamp_str = self.source_table_stream_arn.split('/')[-1]
-
-            # Convert the timestamp string to a datetime object
-            timestamp_without_ms = datetime.strptime(timestamp_str, "%Y-%m-%dT%H:%M:%S.%f").strftime("%Y-%m-%dT%H:%M:%S")
-            timestamp = datetime.strptime(timestamp_without_ms, "%Y-%m-%dT%H:%M:%S")
-
-
-            # Set the timezone to UTC
-            timestamp = timestamp.replace(tzinfo=pytz.UTC)
-
-            # Convert the datetime object to a Unix timestamp
-            self.dynamodb_stream_enabled_ts = int(timestamp.timestamp())
+            self.source_table_stream_arn = upd_table_response['TableDescription']['LatestStreamArn']
 
             logger.info(f"Enabled DynamoDB stream on '{self.source_table_name}' and the stream ARN is '{self.source_table_stream_arn}'. The stream enabled at {self.dynamodb_stream_enabled_ts} epoch time")
 

--- a/target_cfn_template.yaml
+++ b/target_cfn_template.yaml
@@ -151,3 +151,8 @@ Resources:
                 Resource:
                   - !Sub 'arn:aws:s3:::dynamodb-export-to-s3-${AWS::Region}-${AWS::AccountId}/*'
                   - !Sub 'arn:aws:s3:::dynamodb-export-to-s3-${AWS::Region}-${AWS::AccountId}'
+
+Outputs:
+  CrossAccountRoleName:
+    Description: Name of the cross account assume role
+    Value: !Ref CrossAccountAssumeRole


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/cross-account-migration-for-amazon-dynamodb/issues/3

*Description of changes:*
Instead of extracting the timestamp from the DynamoDB Stream ARN, we are now obtaining the timestamp when the stream is actually enabled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
